### PR TITLE
Significant changes in scanning functionality.

### DIFF
--- a/S7Scanner.CLI/Program.cs
+++ b/S7Scanner.CLI/Program.cs
@@ -4,115 +4,147 @@ using System.Text.Json;
 using System.CommandLine;
 using S7Scanner.Lib.Helpers;
 using S7Scanner.Lib.IpScanner;
+using S7Scanner.Lib.Models;
 
-namespace S7Scanner.CLI
+namespace S7Scanner.CLI;
+
+static class Program
 {
-    static class Program
+    static async Task<int> Main(string[] args)
     {
-        private const int SiemensPlcPort = 102;
-
-        static async Task<int> Main(string[] args)
+        var ipRangeOption = new Option<string>("--ip-range")
         {
-            var ipRangeOption = new Option<string>(
-                name: "--ip-range")
-            {
-                Description = "The IP range to scan (e.g., '192.168.1.1-192.168.1.254').",
-                Required = true,
-                AllowMultipleArgumentsPerToken = false
-            };
+            Description = "The IP range to scan (e.g., '192.168.1.1-192.168.1.254').",
+            Required = true,
+            AllowMultipleArgumentsPerToken = false
+        };
 
-            var outputFileOption = new Option<FileInfo>(
-                name: "--output-file")
-            {
-                Description = "Optional. Path to save the results as a JSON file."
-            };
+        // Optional output file
+        var outputFileOption = new Option<FileInfo>("--output-file")
+        {
+            Description = "Optional. Path to save the results as a JSON file."
+        };
 
-            var rootCommand = new RootCommand($"Scans an IP range for open TCP port {SiemensPlcPort} (Siemens S7).");
-            rootCommand.Options.Add(ipRangeOption);
-            rootCommand.Options.Add(outputFileOption);
+        // Optional parameter for timeout, default = 500ms
+        var timeoutOption = new Option<int>("--timeout")
+        {
+            Description = "Connection timeout in milliseconds for each IP.",
+            DefaultValueFactory = _ => 500
+        };
 
-            rootCommand.SetAction(async (parseResult, cancellationToken) => await ExecuteScan(parseResult!.GetValue(ipRangeOption)!, parseResult!.GetValue(outputFileOption)!, cancellationToken));
+        // Optional parameter for parallelism, default = 100
+        var parallelismOption = new Option<int>("--parallelism")
+        {
+            Description = "Number of IPs to scan concurrently.",
+            DefaultValueFactory = _ => 100
+        };
 
-            CommandLineConfiguration configuration = new(rootCommand)
-            {
-                Output = new StringWriter(),
-                Error = TextWriter.Null
-            };
+        var rootCommand = new RootCommand("Scans an IP range for Siemens devices and classifies them as PLC or HMI.");
+        rootCommand.Options.Add(ipRangeOption);
+        rootCommand.Options.Add(outputFileOption);
+        rootCommand.Options.Add(timeoutOption);
+        rootCommand.Options.Add(parallelismOption);
 
-            return await configuration.InvokeAsync(args);
+        // Set action
+        rootCommand.SetAction(async (parseResult, cancellationToken) =>
+        {
+            var ipRange = parseResult.GetValue(ipRangeOption);
+            var outputFile = parseResult.GetValue(outputFileOption);
+            var timeout = parseResult.GetValue(timeoutOption);
+            var parallelism = parseResult.GetValue(parallelismOption);
+
+            await ExecuteScan(ipRange!, outputFile, timeout, parallelism, cancellationToken);
+        });
+
+        return await rootCommand.Parse(args).InvokeAsync();
+    }
+
+    private static async Task ExecuteScan(string ipRange, FileInfo? outputFile, int timeout, int parallelism, CancellationToken cancellationToken)
+    {
+        Console.WriteLine("Starting Siemens Device Scanner...");
+        Console.WriteLine($"IP Range: {ipRange}");
+        Console.WriteLine($"Timeout: {timeout}ms | Parallelism: {parallelism}");
+        if (outputFile != null)
+        {
+            Console.WriteLine($"Output File: {outputFile.FullName}");
         }
+        Console.WriteLine("---------------------------------------------");
 
-        private static async Task ExecuteScan(string ipRange, FileInfo outputFile, CancellationToken cancellationToken)
+        var stopwatch = Stopwatch.StartNew();
+
+        try
         {
-            Console.WriteLine("Starting IP Scanner for Siemens PLCs...");
-            Console.WriteLine($"Target Port: {SiemensPlcPort}");
-            Console.WriteLine($"IP Range: {ipRange}");
+            var ipsToScan = IpRangeParser.Parse(ipRange);
+            var foundDevices = (await IpScannerService.DiscoverDevicesAsync(
+                ipsToScan,
+                timeout,
+                parallelism,
+                cancellationToken)).ToList();
+
+            stopwatch.Stop();
+            Console.WriteLine("---------------------------------------------");
+            Console.WriteLine($"Scan complete in {stopwatch.Elapsed.TotalSeconds:F2} seconds.");
+
+            if (foundDevices.Count == 0)
+            {
+                Console.WriteLine("No devices found.");
+                return;
+            }
+
+            Console.WriteLine($"Found {foundDevices.Count} device(s):");
+            foreach (var device in foundDevices)
+            {
+                Console.WriteLine($"  - {device.IpAddress,-15} | Type: {device.Type}");
+            }
+
             if (outputFile != null)
             {
-                Console.WriteLine($"Output File: {outputFile.FullName}");
-            }
-            Console.WriteLine("---------------------------------------------");
-
-            var stopwatch = Stopwatch.StartNew();
-            var cts = new CancellationTokenSource();
-            Console.CancelKeyPress += (s, e) =>
-            {
-                Console.WriteLine("Cancellation requested. Finishing in-progress tasks...");
-                cts.Cancel();
-                e.Cancel = true;
-            };
-
-            try
-            {
-                var parser = new IpRangeParser();
-                var scanner = new IpScannerService();
-
-                var ipsToScan = parser.Parse(ipRange);
-                var foundIps = await scanner.ScanAsync(ipsToScan, SiemensPlcPort, cts.Token);
-
-                stopwatch.Stop();
-                Console.WriteLine("---------------------------------------------");
-                Console.WriteLine($"Scan complete in {stopwatch.Elapsed.TotalSeconds:F2} seconds.");
-
-                if (!foundIps.Any())
-                {
-                    Console.WriteLine("No devices found with port 102 open.");
-                    return;
-                }
-
-                Console.WriteLine($"Found {foundIps.Count()} device(s):");
-                var foundIpStrings = foundIps.Select(ip => ip.ToString()).ToList();
-                foundIpStrings.ForEach(Console.WriteLine);
-
-                if (outputFile != null)
-                {
-                    await WriteResultsToFile(foundIpStrings, outputFile.FullName);
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.ForegroundColor = ConsoleColor.Red;
-                Console.WriteLine($"\nAn error occurred: {ex.Message}");
-                Console.ResetColor();
+                await WriteResultsToFile(foundDevices, outputFile.FullName);
             }
         }
-
-        private static async Task WriteResultsToFile(List<string> ips, string filePath)
+        catch (OperationCanceledException)
         {
-            try
+            Console.WriteLine("\nScan was cancelled by the user.");
+        }
+        catch (Exception ex)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine($"\nAn error occurred: {ex.Message}");
+            Console.ResetColor();
+        }
+    }
+
+    private static async Task WriteResultsToFile(List<DiscoveredDevice> devices, string filePath)
+    {
+        try
+        {
+            JsonSerializerOptions jsonSerializerOptions = new() { WriteIndented = true };
+            var options = jsonSerializerOptions;
+            var jsonData = new
             {
-                var options = new JsonSerializerOptions { WriteIndented = true };
-                var jsonData = new { FoundIps = ips };
-                string jsonString = JsonSerializer.Serialize(jsonData, options);
-                await File.WriteAllTextAsync(filePath, jsonString);
-                Console.WriteLine($"\nResults successfully written to {filePath}");
-            }
-            catch (Exception ex)
-            {
-                Console.ForegroundColor = ConsoleColor.Red;
-                Console.WriteLine($"\nFailed to write to output file: {ex.Message}");
-                Console.ResetColor();
-            }
+                ScanSummary = new
+                {
+                    Timestamp = DateTime.UtcNow,
+                    DeviceCount = devices.Count,
+                    PlcCount = devices.Count(d => d.Type == DeviceType.PLC),
+                    HmiCount = devices.Count(d => d.Type == DeviceType.HMI),
+                },
+                DiscoveredDevices = devices.ConvertAll(d => new
+                {
+                    IpAddress = d.IpAddress.ToString(),
+                    d.Type
+                })
+            };
+
+            string jsonString = JsonSerializer.Serialize(jsonData, options);
+            await File.WriteAllTextAsync(filePath, jsonString);
+            Console.WriteLine($"\nResults successfully written to {filePath}");
+        }
+        catch (Exception ex)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine($"\nFailed to write to output file: {ex.Message}");
+            Console.ResetColor();
         }
     }
 }

--- a/S7Scanner.Lib/Helpers/IpRangeParser.cs
+++ b/S7Scanner.Lib/Helpers/IpRangeParser.cs
@@ -2,7 +2,7 @@
 
 namespace S7Scanner.Lib.Helpers;
 
-public class IpRangeParser
+public static class IpRangeParser
 {
     /// <summary>
     /// Parses a string representing an IP address or a range of IP addresses and returns the corresponding sequence of
@@ -20,7 +20,7 @@ public class IpRangeParser
     /// addresses in the range are not of the same address family.</exception>
     /// <exception cref="FormatException">Thrown if <paramref name="ipRange"/> is not a valid IP address or range format, or if any IP address in the
     /// range is invalid.</exception>
-    public IEnumerable<IPAddress> Parse(string ipRange)
+    public static IEnumerable<IPAddress> Parse(string ipRange)
     {
         if (string.IsNullOrWhiteSpace(ipRange))
         {

--- a/S7Scanner.Lib/IpScanner/IpScannerService.cs
+++ b/S7Scanner.Lib/IpScanner/IpScannerService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using S7Scanner.Lib.Models;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,50 +9,89 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace S7Scanner.Lib.IpScanner;
-public class IpScannerService
-{
-    private const int DefaultTimeoutMs = 1000;
-    private const int MaxDegreeOfParallelism = 100;
 
-    public async Task<IEnumerable<IPAddress>> ScanAsync(IEnumerable<IPAddress> ips, int port, CancellationToken cancellationToken)
+/// <summary>
+/// Provides functionality to scan a range of IP addresses for Siemens devices and classify them as PLC or HMI.
+/// </summary>
+/// <remarks>This service is designed to identify Siemens devices by scanning specified IP addresses and checking
+/// for open ports. It uses the default Siemens S7 port (102) to detect potential devices and additional ports to
+/// classify them as PLC or HMI. The scanning process supports parallel execution and can be canceled using a <see
+/// cref="CancellationToken"/>.</remarks>
+public static class IpScannerService
+{
+    // The default Siemens S7 port.
+    private const int _siemensS7Port = 102;
+
+    // Ports that typically indicate an HMI device if open.
+    private static readonly int[] _hmiPorts = [2308, 50523, 1033, 5001, 5002, 5800];
+
+    /// <summary>
+    /// Scans a range of IP addresses for Siemens devices and classifies them as PLC or HMI.
+    /// </summary>
+    /// <param name="ips">The collection of IP addresses to scan.</param>
+    /// <param name="timeoutMs">The timeout in milliseconds for each connection attempt.</param>
+    /// <param name="maxDegreeOfParallelism">The maximum number of concurrent scans.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A collection of DiscoveredDevice objects.</returns>
+    public static async Task<IEnumerable<DiscoveredDevice>> DiscoverDevicesAsync(
+        IEnumerable<IPAddress> ips,
+        int timeoutMs,
+        int maxDegreeOfParallelism,
+        CancellationToken cancellationToken)
     {
-        var openIps = new ConcurrentBag<IPAddress>();
+        var discoveredDevices = new ConcurrentBag<DiscoveredDevice>();
         var parallelOptions = new ParallelOptions
         {
-            MaxDegreeOfParallelism = MaxDegreeOfParallelism,
+            MaxDegreeOfParallelism = maxDegreeOfParallelism,
             CancellationToken = cancellationToken
         };
 
+        // Stage 1: Find all devices with the primary port (102) open.
         await Parallel.ForEachAsync(ips, parallelOptions, async (ip, token) =>
         {
-            using var client = new TcpClient();
-            try
+            // Pass the timeout to the check method
+            if (await IsPortOpenAsync(ip, _siemensS7Port, timeoutMs, token))
             {
-                // Use a CancellationTokenSource to implement a timeout
-                using var cts = new CancellationTokenSource(DefaultTimeoutMs);
-                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token, cts.Token);
+                Console.WriteLine($"[CANDIDATE] Found device at {ip}. Checking device type...");
 
-                await client.ConnectAsync(ip, port, linkedCts.Token);
-                openIps.Add(ip);
-                Console.WriteLine($"[FOUND] Host {ip} has port {port} open.");
-            }
-            catch (OperationCanceledException)
-            {
-                // This is expected for timeouts or cancellation
-                Console.WriteLine($"[TIMEOUT] Host {ip} on port {port}.");
-            }
-            catch (SocketException)
-            {
-                // This is expected for closed or unreachable ports
-            }
-            catch (Exception ex)
-            {
-                // Log other unexpected errors
-                Console.WriteLine($"[ERROR] scanning {ip}: {ex.Message}");
+                // Stage 2: Classify the device as PLC or HMI.
+                bool isHmi = false;
+                foreach (var hmiPort in _hmiPorts)
+                {
+                    if (await IsPortOpenAsync(ip, hmiPort, timeoutMs, token))
+                    {
+                        isHmi = true;
+                        Console.WriteLine($"[HMI DETECTED] Host {ip} has HMI port {hmiPort} open.");
+                        break;
+                    }
+                }
+
+                var deviceType = isHmi ? DeviceType.HMI : DeviceType.PLC;
+                discoveredDevices.Add(new DiscoveredDevice(ip, deviceType));
             }
         });
 
-        return openIps.OrderBy(ip => ip, new IpAddressComparer()).ToList();
+        return [.. discoveredDevices.OrderBy(d => d.IpAddress, new IpAddressComparer())];
+    }
+
+    /// <summary>
+    /// Checks if a specific TCP port is open on a given IP address.
+    /// </summary>
+    private static async Task<bool> IsPortOpenAsync(IPAddress ip, int port, int timeoutMs, CancellationToken cancellationToken)
+    {
+        using var client = new TcpClient();
+        try
+        {
+            using var cts = new CancellationTokenSource(timeoutMs);
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, cts.Token);
+
+            await client.ConnectAsync(ip, port, linkedCts.Token);
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
     }
 }
 
@@ -66,7 +106,6 @@ file class IpAddressComparer : IComparer<IPAddress>
         var xBytes = x.GetAddressBytes();
         var yBytes = y.GetAddressBytes();
 
-        // Ensure same family, though the main logic should already do this
         if (xBytes.Length != yBytes.Length)
         {
             return xBytes.Length.CompareTo(yBytes.Length);

--- a/S7Scanner.Lib/Models/DeviceType.cs
+++ b/S7Scanner.Lib/Models/DeviceType.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace S7Scanner.Lib.Models;
+
+/// <summary>
+/// Represents the type of a discovered device.
+/// </summary>
+public enum DeviceType
+{
+    PLC,
+    HMI
+}

--- a/S7Scanner.Lib/Models/DiscoveredDevice.cs
+++ b/S7Scanner.Lib/Models/DiscoveredDevice.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace S7Scanner.Lib.Models;
+
+/// <summary>
+/// Represents a discovered device on the network, including its IP address and type.
+/// </summary>
+/// <param name="IpAddress">The IP address of the device.</param>
+/// <param name="Type">The determined type of the device (PLC or HMI).</param>
+public record DiscoveredDevice(IPAddress IpAddress, DeviceType Type);


### PR DESCRIPTION
- new class `DiscoveredType` to distinguish between PLCs and HMIs

- new enum `DeviceType` for PLC/HMI identification

- `IpRangeParser` is now static

- `IpScannerService` is now static

- second scan round in `IpScannerService` after device with open port 102 was found: check if PLC or HMI using common HMILoad ports and the Sm@rtServer port from the Siemens docs

- adjusted `S7Scanner.CLI.Program` to support PLC and HMI distinguishing and to support more optional parameters (timeout, parallelism)